### PR TITLE
Allow environment variable SKIP_SSL_VALIDATION

### DIFF
--- a/cf/as_user.go
+++ b/cf/as_user.go
@@ -30,8 +30,13 @@ func InitiateUserContext(userContext UserContext) (originalCfHomeDir, currentCfH
 	}
 
 	os.Setenv("CF_HOME", currentCfHomeDir)
+	
+	if os.Getenv("SKIP_SSL_VALIDATION") == "true" {
+		Expect(Cf("api", userContext.ApiUrl, "--skip-ssl-validation")).To(ExitWith(0))
+	} else {
+		Expect(Cf("api", userContext.ApiUrl)).To(ExitWith(0))
+	}
 
-	Expect(Cf("api", userContext.ApiUrl)).To(ExitWith(0))
 	Expect(Cf("auth", userContext.Username, userContext.Password)).To(ExitWith(0))
 
 	return

--- a/cf/as_user_test.go
+++ b/cf/as_user_test.go
@@ -26,11 +26,21 @@ var _ = Describe("AsUser", func() {
 		cf.Cf = FakeCf
 	})
 
+	Context("When SKIP_SSL_VALIDATION is true", func() {
+		It("calls cf api with --skip-ssl-validation", func() {
+			os.Setenv("SKIP_SSL_VALIDATION", "true")
+			cf.AsUser(user, FakeThingsToRunAsUser)
+			Expect(FakeCfCalls[0]).To(Equal([]string{"api", "http://FAKE_API.example.com", "--skip-ssl-validation"}))
+			os.Setenv("SKIP_SSL_VALIDATION", "false")
+		})
+	})
 
-	It("calls cf api", func() {
-		cf.AsUser(user, FakeThingsToRunAsUser)
+	Context("When SKIP_SSL_VALIDATION is not true", func() {
+		It("calls cf api without --skip-ssl-validation", func() {
+			cf.AsUser(user, FakeThingsToRunAsUser)
 
-		Expect(FakeCfCalls[0]).To(Equal([]string{"api", "http://FAKE_API.example.com"}))
+			Expect(FakeCfCalls[0]).To(Equal([]string{"api", "http://FAKE_API.example.com"}))
+		})
 	})
 
 	It("calls cf auth", func() {


### PR DESCRIPTION
This allows running the test suite against dev deployments with self-signed certificates by running `cf api` with the `--skip-ssl-validation` flag to prevent it complaining. Set the environment variable `SKIP_SSL_VALIDATION=true` to activate.
