### PR TITLE
Increase the expected timeout range in api request test

### DIFF
--- a/workflowhelpers/internal/api_test.go
+++ b/workflowhelpers/internal/api_test.go
@@ -83,7 +83,7 @@ var _ = Describe("ApiRequest", func() {
 			failures := InterceptGomegaFailures(func() {
 				ApiRequest(starter, "GET", "/v2/info", nil, timeout)
 			})
-			Expect(failures).To(ContainElement(MatchRegexp("Timed out after 0.00[1-2]s.\nExpected process to exit.  It did not.")))
+			Expect(failures).To(ContainElement(MatchRegexp("Timed out after 0.00[1-5]s.\nExpected process to exit.  It did not.")))
 		})
 	})
 


### PR DESCRIPTION
GH actions is failing unit tests semi-frequently because the timeout
can sometimes take up to 4 seconds, while we expect it to take only 1-2
seconds in this test.

This is likely due to GH actions using underpowered nodes to run tests
as I was not able to replicate the error on my (much more powerful)
local machine.

I bumped the expected timeout range to 1-5 seconds so that we don't fail
unnecessarily on underpowered nodes.

Examples:
* (4 seconds) https://github.com/cloudfoundry/cf-test-helpers/runs/7630968880?check_suite_focus=true
* (3 seconds) https://github.com/cloudfoundry/cf-test-helpers/runs/7601177205?check_suite_focus=true