### PR TITLE
Remove hostname flag from Push

### DIFF
--- a/cf/push.go
+++ b/cf/push.go
@@ -42,8 +42,6 @@ var Push = func(appName string, args ...string) *gexec.Session {
 			app.Buildpacks = append(app.Buildpacks, args[i+1])
 		case "-c":
 			app.Command = args[i+1]
-		case "-d":
-			app.Routes = append(app.Routes, map[string]string{"route": fmt.Sprintf("%s.%s", appName, args[i+1])})
 		case "-i":
 			instances, err := strconv.Atoi(args[i+1])
 			if err != nil {


### PR DESCRIPTION
The cf CLI removed `--hostname` and `-d` flags from `cf push` back in v7.0.0. We should not support these options anymore either.

This change will cause `-d` to be silently ignored if passed into `Push()`.