### PR TITLE
Remove the travis button from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/cloudfoundry/cf-test-helpers.svg)](https://travis-ci.org/cloudfoundry/cf-test-helpers)
 cf-test-helpers
 ===============
 


### PR DESCRIPTION
We're not tracking this repo in Travis CI anymore.