### PR TITLE
Run tests in parallel

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -8,4 +8,5 @@ go run github.com/onsi/ginkgo/v2/ginkgo \
     --randomize-suites \
     --race \
     --trace \
-    -r
+    -r \
+    -p

--- a/workflowhelpers/internal/space_test.go
+++ b/workflowhelpers/internal/space_test.go
@@ -27,17 +27,17 @@ var _ = Describe("TestSpace", func() {
 	Describe("NewRegularTestSpace", func() {
 		It("generates a quotaDefinitionName", func() {
 			testSpace := NewRegularTestSpace(&cfg, quotaLimit)
-			Expect(testSpace.QuotaDefinitionName).To(MatchRegexp("%s-[0-9]-QUOTA-.*", namePrefix))
+			Expect(testSpace.QuotaDefinitionName).To(MatchRegexp("%s-[0-9]*-QUOTA-.*", namePrefix))
 		})
 
 		It("generates an organizationName", func() {
 			testSpace := NewRegularTestSpace(&cfg, quotaLimit)
-			Expect(testSpace.OrganizationName()).To(MatchRegexp("%s-[0-9]-ORG-.*", namePrefix))
+			Expect(testSpace.OrganizationName()).To(MatchRegexp("%s-[0-9]*-ORG-.*", namePrefix))
 		})
 
 		It("generates a spaceName", func() {
 			testSpace := NewRegularTestSpace(&cfg, quotaLimit)
-			Expect(testSpace.SpaceName()).To(MatchRegexp("%s-[0-9]-SPACE-.*", namePrefix))
+			Expect(testSpace.SpaceName()).To(MatchRegexp("%s-[0-9]*-SPACE-.*", namePrefix))
 		})
 
 		It("sets a timeout for cf commands", func() {


### PR DESCRIPTION
Add `-p` to ginkgo flags in test script, which will run tests in parallel.

Update the NewRegularTestSpace tests to accept multiple-digit numbers in names. They were sometimes failing in parallel because names were coming back with multiple digits (i.e. "13", "21") where it expected only single digits.