### PR TITLE
Add support for user origins

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 
 	AdminUser     string `json:"admin_user"`
 	AdminPassword string `json:"admin_password"`
+	AdminOrigin   string `json:"admin_origin"`
 
 	AdminClient       string `json:"admin_client"`
 	AdminClientSecret string `json:"admin_client_secret"`
@@ -23,6 +24,8 @@ type Config struct {
 	ShouldKeepUser       bool   `json:"keep_user_at_suite_end"`
 	ExistingUser         string `json:"existing_user"`
 	ExistingUserPassword string `json:"existing_user_password"`
+
+	UserOrigin string `json:"user_origin"`
 
 	ExistingClient       string `json:"existing_client"`
 	ExistingClientSecret string `json:"existing_client_secret"`
@@ -258,6 +261,10 @@ func (c *Config) GetExistingUserPassword() string {
 	return c.ExistingUserPassword
 }
 
+func (c *Config) GetUserOrigin() string {
+	return c.UserOrigin
+}
+
 func (c *Config) GetConfigurableTestPassword() string {
 	return c.ConfigurableTestPassword
 }
@@ -272,6 +279,10 @@ func (c *Config) GetAdminUser() string {
 
 func (c *Config) GetAdminPassword() string {
 	return c.AdminPassword
+}
+
+func (c *Config) GetAdminOrigin() string {
+	return c.AdminOrigin
 }
 
 func (c *Config) GetUseExistingOrganization() bool {

--- a/workflowhelpers/internal/cf_auth.go
+++ b/workflowhelpers/internal/cf_auth.go
@@ -13,8 +13,13 @@ import (
 const VerboseAuth = "RELINT_VERBOSE_AUTH"
 const CFAuthRetries = 2
 
-func CfAuth(cmdStarter internal.Starter, reporter internal.Reporter, user string, password string, timeout time.Duration) error {
+func CfAuth(cmdStarter internal.Starter, reporter internal.Reporter, user string, password string, origin string, timeout time.Duration) error {
 	args := []string{"auth", user, password}
+
+	if origin != "" {
+		args = append(args, "--origin", origin)
+	}
+
 	if os.Getenv(VerboseAuth) == "true" {
 		args = append(args, "-v")
 	}

--- a/workflowhelpers/internal/cf_auth_test.go
+++ b/workflowhelpers/internal/cf_auth_test.go
@@ -18,6 +18,7 @@ import (
 var _ = Describe("cf auth", func() {
 	var (
 		password string
+		origin   string
 
 		cmdStarter *fakes.FakeCmdStarter
 
@@ -28,6 +29,7 @@ var _ = Describe("cf auth", func() {
 
 	BeforeEach(func() {
 		password = "foobar"
+		origin = ""
 		cmdStarter = fakes.NewFakeCmdStarter()
 		redactor = internal.NewRedactor(password)
 		reporterOutput = bytes.NewBuffer([]byte{})
@@ -36,7 +38,7 @@ var _ = Describe("cf auth", func() {
 
 	Describe("CfAuth", func() {
 		It("runs the cf auth command", func() {
-			err := CfAuth(cmdStarter, redactingReporter, "user", password, 5*time.Second)
+			err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cmdStarter.TotalCallsToStart).To(Equal(1))
@@ -45,7 +47,7 @@ var _ = Describe("cf auth", func() {
 		})
 
 		It("does not reveal the password", func() {
-			err := CfAuth(cmdStarter, redactingReporter, "user", password, 5*time.Second)
+			err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(reporterOutput.String()).To(ContainSubstring("REDACTED"))
@@ -57,7 +59,7 @@ var _ = Describe("cf auth", func() {
 			cmdStarter.ToReturn[0].SleepTime = timeout
 			cmdStarter.ToReturn[1].SleepTime = timeout
 
-			err := CfAuth(cmdStarter, redactingReporter, "user", password, time.Duration(timeout)*time.Second)
+			err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, time.Duration(timeout)*time.Second)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Timed out after %d", timeout)))
 		})
@@ -68,10 +70,23 @@ var _ = Describe("cf auth", func() {
 			})
 
 			It("errors", func() {
-				err := CfAuth(cmdStarter, redactingReporter, "user", password, 5*time.Second)
+				err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError("something went wrong"))
+			})
+		})
+
+		Context("when the origin is set", func() {
+			BeforeEach(func() {
+				origin = "origin"
+			})
+
+			It("calls cf auth with the origin flag", func() {
+				err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmdStarter.CalledWith[0].Executable).To(Equal("cf"))
+				Expect(cmdStarter.CalledWith[0].Args).To(Equal([]string{"auth", "user", "foobar", "--origin", "origin"}))
 			})
 		})
 
@@ -85,7 +100,7 @@ var _ = Describe("cf auth", func() {
 			})
 
 			It("does not reveal the password", func() {
-				err := CfAuth(cmdStarter, redactingReporter, "user", password, 5*time.Second)
+				err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cmdStarter.CalledWith[0].Executable).To(Equal("cf"))
 				Expect(cmdStarter.CalledWith[0].Args).To(Equal([]string{"auth", "user", "foobar", "-v"}))
@@ -94,7 +109,7 @@ var _ = Describe("cf auth", func() {
 
 		Context("retries", func() {
 			It("does not retry and succeeds when cf auth is successful on the first try", func() {
-				err := CfAuth(cmdStarter, redactingReporter, "user", password, 5*time.Second)
+				err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cmdStarter.TotalCallsToStart).To(Equal(1))
@@ -114,7 +129,7 @@ var _ = Describe("cf auth", func() {
 				It("retries once and succeeds when cf auth times out on the first try and succeeds on the second try", func() {
 					cmdStarter.ToReturn[0].SleepTime = 6
 
-					err := CfAuth(cmdStarter, redactingReporter, "user", password, 5*time.Second)
+					err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
 
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -122,7 +137,7 @@ var _ = Describe("cf auth", func() {
 				It("retries once and succeeds when cf auth exists with a non-zero exit code on the first try and succeeds on the second try", func() {
 					cmdStarter.ToReturn[0].ExitCode = 1
 
-					err := CfAuth(cmdStarter, redactingReporter, "user", password, 5*time.Second)
+					err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
 
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -131,7 +146,7 @@ var _ = Describe("cf auth", func() {
 					cmdStarter.ToReturn[0].ExitCode = 1
 					cmdStarter.ToReturn[1].SleepTime = 6
 
-					err := CfAuth(cmdStarter, redactingReporter, "user", password, 5*time.Second)
+					err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
 
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("cf auth command timed out"))
@@ -141,7 +156,7 @@ var _ = Describe("cf auth", func() {
 					cmdStarter.ToReturn[0].ExitCode = 1
 					cmdStarter.ToReturn[1].ExitCode = 5
 
-					err := CfAuth(cmdStarter, redactingReporter, "user", password, 5*time.Second)
+					err := CfAuth(cmdStarter, redactingReporter, "user", password, origin, 5*time.Second)
 
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(MatchError("cf auth command exited with 5"))

--- a/workflowhelpers/internal/fakes/fake_user_values.go
+++ b/workflowhelpers/internal/fakes/fake_user_values.go
@@ -3,12 +3,14 @@ package fakes
 type FakeUserValues struct {
 	username string
 	password string
+	origin   string
 }
 
-func NewFakeUserValues(username, password string) *FakeUserValues {
+func NewFakeUserValues(username, password, origin string) *FakeUserValues {
 	return &FakeUserValues{
 		username: username,
 		password: password,
+		origin: origin,
 	}
 }
 
@@ -18,4 +20,8 @@ func (user *FakeUserValues) Username() string {
 
 func (user *FakeUserValues) Password() string {
 	return user.password
+}
+
+func (user *FakeUserValues) Origin() string {
+	return user.origin
 }

--- a/workflowhelpers/internal/user.go
+++ b/workflowhelpers/internal/user.go
@@ -17,6 +17,7 @@ import (
 type TestUser struct {
 	username       string
 	password       string
+	origin         string
 	cmdStarter     internal.Starter
 	timeout        time.Duration
 	shouldKeepUser bool
@@ -26,6 +27,7 @@ type UserConfig interface {
 	GetUseExistingUser() bool
 	GetExistingUser() string
 	GetExistingUserPassword() string
+	GetUserOrigin() string
 	GetShouldKeepUser() bool
 	GetConfigurableTestPassword() string
 }
@@ -40,6 +42,7 @@ type userConfig interface {
 type AdminUserConfig interface {
 	GetAdminUser() string
 	GetAdminPassword() string
+	GetAdminOrigin() string
 }
 
 type ClientConfig interface {
@@ -53,14 +56,16 @@ type AdminClientConfig interface {
 }
 
 func NewTestUser(config userConfig, cmdStarter internal.Starter) *TestUser {
-	var regUser, regUserPass string
+	var regUser, regUserPass, regUserOrigin string
 
 	if config.GetUseExistingUser() {
 		regUser = config.GetExistingUser()
 		regUserPass = config.GetExistingUserPassword()
+		regUserOrigin = config.GetUserOrigin()
 	} else {
 		regUser = generator.PrefixedRandomName(config.GetNamePrefix(), "USER")
 		regUserPass = generatePassword()
+		regUserOrigin = config.GetUserOrigin()
 	}
 
 	if config.GetConfigurableTestPassword() != "" {
@@ -70,6 +75,7 @@ func NewTestUser(config userConfig, cmdStarter internal.Starter) *TestUser {
 	return &TestUser{
 		username:       regUser,
 		password:       regUserPass,
+		origin:         regUserOrigin,
 		cmdStarter:     cmdStarter,
 		timeout:        config.GetScaledTimeout(1 * time.Minute),
 		shouldKeepUser: config.GetShouldKeepUser(),
@@ -80,6 +86,7 @@ func NewAdminUser(config AdminUserConfig, cmdStarter internal.Starter) *TestUser
 	return &TestUser{
 		username:   config.GetAdminUser(),
 		password:   config.GetAdminPassword(),
+		origin:     config.GetAdminOrigin(),
 		cmdStarter: cmdStarter,
 	}
 }
@@ -123,6 +130,10 @@ func (user *TestUser) Username() string {
 
 func (user *TestUser) Password() string {
 	return user.password
+}
+
+func (user *TestUser) Origin() string {
+	return user.origin
 }
 
 func (user *TestUser) ShouldRemain() bool {

--- a/workflowhelpers/internal/user_test.go
+++ b/workflowhelpers/internal/user_test.go
@@ -14,13 +14,14 @@ var _ = Describe("User", func() {
 	var cfg *config.Config
 
 	Describe("NewTestUser", func() {
-		var existingUser, existingUserPassword string
+		var existingUser, existingUserPassword, userOrigin string
 		var useExistingUser bool
 		var configurableTestPassword string
 
 		BeforeEach(func() {
 			useExistingUser = false
 			configurableTestPassword = ""
+			userOrigin = ""
 		})
 
 		JustBeforeEach(func() {
@@ -28,6 +29,7 @@ var _ = Describe("User", func() {
 				NamePrefix:               "UNIT-TESTS",
 				UseExistingUser:          useExistingUser,
 				ExistingUser:             existingUser,
+				UserOrigin:               userOrigin,
 				ExistingUserPassword:     existingUserPassword,
 				ConfigurableTestPassword: configurableTestPassword,
 			}
@@ -43,6 +45,18 @@ var _ = Describe("User", func() {
 			password1 := NewTestUser(cfg, &fakes.FakeCmdStarter{}).Password()
 			password2 := NewTestUser(cfg, &fakes.FakeCmdStarter{}).Password()
 			Expect(password1).ToNot(Equal(password2))
+		})
+
+		Context("when the user origin is specified", func() {
+			BeforeEach(func() {
+				userOrigin = "my-test-user-origin"
+			})
+
+			It("uses the Origin", func() {
+				user := NewTestUser(cfg, &fakes.FakeCmdStarter{})
+				Expect(user.Origin()).To(Equal(userOrigin))
+			})
+
 		})
 
 		Context("when the config specifies that an existing user should be used", func() {

--- a/workflowhelpers/test_suite_setup_test.go
+++ b/workflowhelpers/test_suite_setup_test.go
@@ -293,8 +293,8 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			regularUserCmdStarter = starterFakes.NewFakeCmdStarter()
 			adminUserCmdStarter = starterFakes.NewFakeCmdStarter()
 
-			fakeRegularUserValues = fakes.NewFakeUserValues("username", "password")
-			fakeAdminUserValues = fakes.NewFakeUserValues("admin", "admin")
+			fakeRegularUserValues = fakes.NewFakeUserValues("username", "password", "")
+			fakeAdminUserValues = fakes.NewFakeUserValues("admin", "admin", "")
 			fakeSpaceValues = fakes.NewFakeSpaceValues("org", "space")
 
 			regularUserContext = UserContext{
@@ -396,8 +396,8 @@ var _ = Describe("ReproducibleTestSuiteSetup", func() {
 			regularUserCmdStarter = starterFakes.NewFakeCmdStarter()
 			adminUserCmdStarter = starterFakes.NewFakeCmdStarter()
 
-			fakeRegularUserValues = fakes.NewFakeUserValues("username", "password")
-			fakeAdminUserValues = fakes.NewFakeUserValues("admin", "admin")
+			fakeRegularUserValues = fakes.NewFakeUserValues("username", "password", "")
+			fakeAdminUserValues = fakes.NewFakeUserValues("admin", "admin", "")
 			fakeSpaceValues = fakes.NewFakeSpaceValues("org", "space")
 
 			regularUserContext = UserContext{

--- a/workflowhelpers/user_context.go
+++ b/workflowhelpers/user_context.go
@@ -19,6 +19,7 @@ import (
 type userValues interface {
 	Username() string
 	Password() string
+	Origin()   string
 }
 
 type spaceValues interface {
@@ -40,6 +41,7 @@ type UserContext struct {
 	Password string
 	Org      string
 	Space    string
+	Origin   string
 
 	UseClientCredentials bool
 }
@@ -74,6 +76,7 @@ func NewUserContext(apiUrl string, testUser userValues, testSpace spaceValues, s
 		ApiUrl:            apiUrl,
 		Username:          testUser.Username(),
 		Password:          testUser.Password(),
+		Origin:            testUser.Origin(),
 		TestSpace:         testSpace,
 		TestUser:          testUser,
 		Org:               org,
@@ -100,7 +103,7 @@ func (uc UserContext) Login() {
 	if uc.UseClientCredentials {
 		err = workflowhelpersinternal.CfClientAuth(uc.CommandStarter, redactingReporter, uc.TestUser.Username(), uc.TestUser.Password(), uc.Timeout)
 	} else {
-		err = workflowhelpersinternal.CfAuth(uc.CommandStarter, redactingReporter, uc.TestUser.Username(), uc.TestUser.Password(), uc.Timeout)
+		err = workflowhelpersinternal.CfAuth(uc.CommandStarter, redactingReporter, uc.TestUser.Username(), uc.TestUser.Password(), uc.TestUser.Origin(), uc.Timeout)
 	}
 
 	Expect(err).NotTo(HaveOccurred())

--- a/workflowhelpers/user_context_test.go
+++ b/workflowhelpers/user_context_test.go
@@ -44,6 +44,10 @@ var _ = Describe("UserContext", func() {
 			Expect(createUser().Password).To(Equal(testUser.Password()))
 		})
 
+		It("sets UserContext.Origin", func() {
+			Expect(createUser().Origin).To(Equal(testUser.Origin()))
+		})
+
 		It("sets UserContext.Org", func() {
 			Expect(createUser().Org).To(Equal(testSpace.OrganizationName()))
 		})
@@ -120,6 +124,20 @@ var _ = Describe("UserContext", func() {
 
 				Expect(fakeStarter.CalledWith[1].Executable).To(Equal("cf"))
 				Expect(fakeStarter.CalledWith[1].Args).To(Equal([]string{"auth", testUser.Username(), testUser.Password(), "--client-credentials"}))
+			})
+		})
+
+		Context("when Origin is set", func() {
+			BeforeEach(func() {
+				testUser = internal.NewTestUser(&config.Config{UserOrigin: "origin", UseExistingUser: true}, &fakes.FakeCmdStarter{})
+			})
+			It("uses --origin auth method", func() {
+				userContext.Login()
+
+				Expect(fakeStarter.CalledWith).To(HaveLen(2))
+
+				Expect(fakeStarter.CalledWith[1].Executable).To(Equal("cf"))
+				Expect(fakeStarter.CalledWith[1].Args).To(Equal([]string{"auth", testUser.Username(), testUser.Password(), "--origin", testUser.Origin()}))
 			})
 		})
 


### PR DESCRIPTION
Adds support to specify the user origin that will be used when using
`cf auth`.

Co-authored-by: Gareth Evans <g.evans@sap.com>
