### PR TITLE
fix(go.mod): Tidy go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/cloudfoundry/cf-test-helpers/v2
 
-go 1.22
-toolchain go1.22.6
+go 1.22.0
+
+toolchain go1.22.8
 
 require (
 	github.com/onsi/ginkgo/v2 v2.21.0


### PR DESCRIPTION
Fixes CI ([failing build](https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-test-helpers/jobs/run-unit-tests/builds/51)) by running `go mod tidy`.