### PR TITLE
Add --show-error to CurlWithCustomReporter

### DIFF
--- a/helpers/internal/curl.go
+++ b/helpers/internal/curl.go
@@ -11,10 +11,11 @@ func Curl(cmdStarter internal.Starter, skipSsl bool, args ...string) *gexec.Sess
 }
 
 func CurlWithCustomReporter(cmdStarter internal.Starter, reporter internal.Reporter, skipSsl bool, args ...string) *gexec.Session {
-	curlArgs := append([]string{"-s"}, args...)
-	curlArgs = append([]string{"-H", "Expect:"}, curlArgs...)
+	curlArgs := append([]string{"--silent"}, args...)
+	curlArgs = append([]string{"--show-error"}, curlArgs...)
+	curlArgs = append([]string{"--header", "Expect:"}, curlArgs...)
 	if skipSsl {
-		curlArgs = append([]string{"-k"}, curlArgs...)
+		curlArgs = append([]string{"--insecure"}, curlArgs...)
 	}
 
 	request, err := cmdStarter.Start(reporter, "curl", curlArgs...)

--- a/helpers/internal/curl_test.go
+++ b/helpers/internal/curl_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Curl", func() {
 			Expect(session).To(Exit(0))
 			Expect(session.Out).To(Say("HTTP/1.1 200 OK"))
 			Expect(starter.CalledWith[0].Executable).To(Equal("curl"))
-			Expect(starter.CalledWith[0].Args).To(ConsistOf("-H", "Expect:", "-I", "-s", "http://example.com"))
+			Expect(starter.CalledWith[0].Args).To(ConsistOf("--header", "Expect:", "-I", "--show-error", "--silent", "http://example.com"))
 		})
 
 		It("uses the specified reporter", func() {


### PR DESCRIPTION
Use long-form flags to make the errors more readable.