### PR TITLE
ci(dependabot): Bump GHA dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
----
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Configures dependabot to bump dependencies for GitHub Actions on a weekly basis.

Also, updates the go module bumps to be weekly instead of daily. This conforms to how we're configuring other repos as well. Weekly bumps are timely enough and don't cause as much PR overload.