### PR TITLE
Added helper functions for ipv6 implementation

### DIFF
--- a/helpers/app_commands.go
+++ b/helpers/app_commands.go
@@ -27,6 +27,12 @@ func CurlApp(cfg helpersinternal.CurlConfig, appName, path string, args ...strin
 	return appCurler.CurlAndWait(cfg, appName, path, CURL_TIMEOUT, args...)
 }
 
+// Curls an app's endpoint and returns the body content and the HTTP status code
+func CurlAppWithStatusCode(cfg helpersinternal.CurlConfig, appName, path string, args ...string) string {
+	appCurler := helpersinternal.NewAppCurler(Curl, cfg)
+	return appCurler.CurlWithStatusCode(cfg, appName, path, CURL_TIMEOUT, args...)
+}
+
 // Curls an app's root endpoint and exit successfully before the default timeout
 func CurlAppRoot(cfg helpersinternal.CurlConfig, appName string) string {
 	appCurler := helpersinternal.NewAppCurler(Curl, cfg)

--- a/helpers/internal/app_curler.go
+++ b/helpers/internal/app_curler.go
@@ -34,3 +34,14 @@ func (appCurler *AppCurler) CurlAndWait(cfg CurlConfig, appName string, path str
 	gomega.ExpectWithOffset(3, string(curlCmd.Err.Contents())).To(gomega.HaveLen(0))
 	return string(curlCmd.Out.Contents())
 }
+
+func (appCurler *AppCurler) CurlWithStatusCode(cfg CurlConfig, appName string, path string, timeout time.Duration, args ...string) string {
+    appUri := appCurler.UriCreator.AppUri(appName, path)
+    curlArgs := append([]string{"-s", "-w", "\n%{http_code}", appUri}, args...)
+
+    curlCmd := appCurler.CurlFunc(cfg, curlArgs...).Wait(timeout)
+	
+    gomega.ExpectWithOffset(3, curlCmd).To(gexec.Exit(0))
+    gomega.ExpectWithOffset(3, string(curlCmd.Err.Contents())).To(gomega.HaveLen(0))
+    return string(curlCmd.Out.Contents())
+}


### PR DESCRIPTION
Added test helper fucntions for IPv6 implementation. With the two added functions , when curl an app - in the response we are returning body content and HTTP status code. The second one is needed for additional testing purposes.